### PR TITLE
💚 ci: add commitizen cz bump workflow

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
 
       - name: Create bump and changelog
-        uses: commitizen-tools/commitizen-action@master
+        uses: commitizen-tools/commitizen-action@bb4f1df6601e2a1a891506581b0c53acdc88e07d
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           body_path: "body.md"
           tag_name: ${{ env.REVISION }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Introduce a GitHub Actions workflow that runs Commitizen to bump the version, generate a changelog body, and publish a GitHub release on non-release commits to main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds automated versioning and release publishing via GitHub Actions.
> 
> - New workflow `.github/workflows/bumpversion.yml` runs on pushes to `main` excluding commits starting with `🔖 bump(release):`
> - Uses `commitizen-tools/commitizen-action` to bump version and generate `body.md` changelog
> - Publishes a GitHub Release with `softprops/action-gh-release` using `body.md` and `${{ env.REVISION }}` as the tag; uses repo PAT for checkout and Commitizen, and grants `contents: write`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 985514478f326af0bacfb7309f1f0e1feb032325. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->