### PR TITLE
ci: fix  cz_gitmoji to cz-conventional-gitmoji

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -19,8 +19,8 @@ jobs:
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
 
-      - name: Install cz_gitmoji
-        run: python -m pip install cz_gitmoji
+      - name: Install cz-conventional-gitmoji
+        run: python -m pip install cz-conventional-gitmoji
 
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@bb4f1df6601e2a1a891506581b0c53acdc88e07d


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch the CI workflow from installing `cz_gitmoji` to `cz-conventional-gitmoji` in the bumpversion job.