### PR TITLE
💚 ci: remove redundant cz-conventional-gitmoji install step

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -19,14 +19,12 @@ jobs:
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
 
-      - name: Install cz-conventional-gitmoji
-        run: python -m pip install cz-conventional-gitmoji
-
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@bb4f1df6601e2a1a891506581b0c53acdc88e07d
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
+          extra_requirements: cz-conventional-gitmoji
 
       - name: Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Simplify the bumpversion GitHub Actions workflow by removing a redundant pip install step and passing cz-conventional-gitmoji as an extra requirement to commitizen-action.