### PR TITLE
ci: 💚 fix commitizen bump workflow

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -19,6 +19,9 @@ jobs:
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
 
+      - name: Fetch tags
+        run: git fetch --force --tags
+
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@bb4f1df6601e2a1a891506581b0c53acdc88e07d
         with:

--- a/scripts/test-cz-bump.sh
+++ b/scripts/test-cz-bump.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Test the cz-bump workflow locally using act
+# Usage: ./scripts/test-cz-bump.sh
+# Example: ./scripts/test-cz-bump.sh
+
+echo "🧪 Testing bumpversion workflow (dry-run)"
+echo ""
+
+# Run act with push event
+act -n push \
+  -W .github/workflows/bumpversion.yml \
+  -s PERSONAL_ACCESS_TOKEN=fake \
+  -s GITHUB_TOKEN=fake \
+  --container-architecture linux/amd64 \
+  --verbose
+
+echo ""
+echo "✅ Test completed!"
+echo "Note: Authentication/push/release steps may fail locally (expected behavior)"


### PR DESCRIPTION
## Summary by Sourcery

Update the bumpversion CI workflow to properly fetch Git tags before running the Commitizen bump action and add a helper script for locally testing the workflow with act.

CI:
- Fetch Git tags in the bumpversion workflow to ensure Commitizen has access to tag history.

Tests:
- Add a local helper script to run the bumpversion workflow with act in dry-run mode for easier testing.