### PR TITLE
ci: simplify tag fetching in bumpversion workflow

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -18,18 +18,20 @@ jobs:
         with:
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
-
-      - name: Fetch tags
-        run: git fetch --force --tags
+          fetch-tags: true
 
       - name: Create bump and changelog
+        id: cz
         uses: commitizen-tools/commitizen-action@bb4f1df6601e2a1a891506581b0c53acdc88e07d
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          commitizen_version: "4.10.1"
           changelog_increment_filename: body.md
           extra_requirements: cz-conventional-gitmoji
+          debug: "true"
 
       - name: Release
+        if: steps.cz.outputs.version != steps.cz.outputs.previous_version
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           body_path: "body.md"


### PR DESCRIPTION
## Summary by Sourcery

Update the bumpversion workflow to fetch tags correctly, configure Commitizen explicitly, and gate releases on version changes while adding a helper script for local dry-run testing with act.

CI:
- Adjust bumpversion workflow to fetch tags, pin Commitizen version, enable debug output, and only create a release when the version actually changes.

Tests:
- Add a helper script to run the bumpversion workflow locally with act in dry-run mode.